### PR TITLE
Allow linting *.d.ts files by default.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 
 var opts = require('../options.js')
-require('../custom-engine.js').cli(opts)
+var Linter = require('../custom-engine.js')
+
+opts.linter = new Linter(opts)
+require('standard-engine').cli(opts)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 var opts = require('../options.js')
-require('standard-engine').cli(opts)
+require('../custom-engine.js').cli(opts)

--- a/custom-engine.js
+++ b/custom-engine.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const Linter = require('standard-engine').linter
+
+var DEFAULT_PATTERNS = [
+  '**/*.js',
+  '**/*.jsx',
+  '**/*.mjs',
+  '**/*.cjs',
+  '**/*.d.ts'
+]
+
+class CustomLinter extends Linter {
+  lintFiles (files, opts, cb) {
+    if (!files || files.length === 0) {
+      files = DEFAULT_PATTERNS
+    }
+    return super.lintFiles(files, opts, cb)
+  }
+}
+
+module.exports = CustomLinter

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 // programmatic usage
-var Linter = require('standard-engine').linter
-
+var Linter = require('./custom-engine.js')
 var opts = require('./options.js')
 
 module.exports = new Linter(opts)

--- a/options.js
+++ b/options.js
@@ -11,9 +11,6 @@ module.exports = {
   eslint: require('eslint'),
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
-    // parserOptions: {
-    //   project: path.join(process.cwd(), './tsconfig.json')
-    // }
   },
   parseOpts: (opts, packageOpts, rootDir) => {
     opts.eslintConfig = opts.eslintConfig || {}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
-    "standard-engine": "github:standard/standard-engine#custom-linter",
+    "standard-engine": "github:Raynos/standard-engine#v12.0.1-custom-linter",
     "typescript": "3.8.3"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
-    "standard-engine": "12.0.0",
+    "standard-engine": "github:standard/standard-engine#custom-linter",
     "typescript": "3.8.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
This is super useful for extending type safety to the
actual type annotations like *.d.ts